### PR TITLE
moved stuff around from arena to alloc

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -164,6 +164,40 @@ pub trait Alloc {
             return new_ptr;
         }
     }
+
+    
+    #[inline]
+    fn alloc_ptr<T>(&self) -> Option<NonNull<T>> {
+        Some(self.alloc(Layout::new::<T>())?.cast())
+    }
+
+
+    #[inline]
+    fn alloc_array_ptr<T>(&self, len: usize) -> Option<NonNull<T>> {
+        Some(self.alloc(Layout::array::<T>(len).ok()?)?.cast())
+    }
+
+
+    #[inline]
+    fn alloc_new<T>(&self, value: T) -> Option<&mut T> {
+        let mut ptr = self.alloc_ptr::<T>()?;
+        unsafe {
+            ptr.as_ptr().write(value);
+            Some(ptr.as_mut())
+        }
+    }
+
+
+    #[inline]
+    fn alloc_str<'a>(&'a self, value: &str) -> Option<&'a str> {
+        unsafe {
+            let bytes = self.alloc_array_ptr(value.len())?;
+            core::ptr::copy_nonoverlapping(value.as_ptr(), bytes.as_ptr(), value.len());
+            Some(core::str::from_utf8_unchecked(
+                core::slice::from_raw_parts(bytes.as_ptr(), value.len())
+            ))
+        }
+    }
 }
 
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -110,35 +110,25 @@ impl<A: Alloc> Arena<A> {
             max_block_size: usize::MAX.into(),
         }
     }
-
-
+    
     #[inline]
     pub fn alloc_ptr<T>(&self) -> NonNull<T> {
-        self.alloc(Layout::new::<T>()).unwrap().cast()
+        <Self as Alloc>::alloc_ptr(self).unwrap()
     }
 
     #[inline]
     pub fn alloc_array_ptr<T>(&self, len: usize) -> NonNull<T> {
-        self.alloc(Layout::array::<T>(len).unwrap()).unwrap().cast()
+        <Self as Alloc>::alloc_array_ptr(self, len).unwrap()
     }
 
     #[inline]
     pub fn alloc_new<T>(&self, value: T) -> &mut T {
-        let mut ptr = self.alloc_ptr::<T>();
-        unsafe {
-            ptr.as_ptr().write(value);
-            ptr.as_mut()
-        }
+        <Self as Alloc>::alloc_new(self, value).unwrap()
     }
 
     #[inline]
     pub fn alloc_str<'a>(&'a self, value: &str) -> &'a str {
-        unsafe {
-            let bytes = self.alloc_array_ptr(value.len());
-            core::ptr::copy_nonoverlapping(value.as_ptr(), bytes.as_ptr(), value.len());
-            core::str::from_utf8_unchecked(
-                core::slice::from_raw_parts(bytes.as_ptr(), value.len()))
-        }
+        <Self as Alloc>::alloc_str(self, value).unwrap()
     }
 
     // pred: (block, cap).

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -141,7 +141,6 @@ impl<A: Alloc> Arena<A> {
         }
     }
 
-
     // pred: (block, cap).
     #[inline]
     fn reset_until<F: Fn(NonNull<BlockHeader>, usize) -> bool>(&self, f: F) {


### PR DESCRIPTION
moved the following:
- alloc_ptr
- alloc_array_ptr
- alloc_new
- alloc_str to the Alloc trait

Also made it so the functions return None instead of panicking on failure. The API for the Arena is still the same, panicking on failure